### PR TITLE
chore(bower): adding bower.json to fix bower installs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "xdomain",
+  "version": "0.5.6",
+  "homepage": "https://github.com/jpillora/xdomain",
+  "authors": [
+    "Jaime Pillora <dev@jpillora.com>"
+  ],
+  "description": "CORS support that rocks.",
+  "main": "dist/0.5/xdomain.min.js",
+  "keywords": [
+    "cors",
+    "cross",
+    "domain",
+    "requests"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "example",
+    "*.html",
+    "src"
+  ]
+}


### PR DESCRIPTION
bower install is currently installing the old version 0.5.5. Adding a bower.json to help target specific versions to avoid the bower headache that I just went through.

Thanks for a great solution and library!
