### PR TITLE
Fix xHook readyBody.response for latest AngularJs

### DIFF
--- a/vendor/xhook.js
+++ b/vendor/xhook.js
@@ -124,7 +124,7 @@ window.XMLHttpRequest = function() {
   };
   readyBody = function() {
     facade.responseType = response.type || '';
-    facade.response = response.data || null;
+    facade.response = response.data || response.text || null;
     facade.responseText = response.text || response.data || '';
     facade.responseXML = response.xml || null;
   };


### PR DESCRIPTION
A recent change in AngularJs broke xdomain resulting in an empty response
see [angular file changes](https://github.com/angular/angular.js/commit/a9cccbe14f1bd9048f5dab4443f58c804d4259a1#diff-fc6d3d48fd6597bd97d30eab9497841bR90)
