### PR TITLE
fixed bower not downloading js files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,13 +1,21 @@
 {
   "name": "jpillora/xdomain",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "main": "dist/0.6/xdomain.js",
   "license": "MIT",
   "ignore": [
-    "*",
-    "!bower.json",
-    "!dist/0.6/xdomain.js",
-    "!dist/0.6/xdomain.min.js"
+    "example",
+    "src",
+    "test",
+    "vendor",
+    ".gitignore",
+    ".travis.yml",
+    "CONTRIBUTING.md",
+    "Gruntsource.json",
+    "README.md",
+    "index.html",
+    "dist/0.4",
+    "dist/0.5"
   ],
   "dependencies": {},
   "devDependencies": {}


### PR DESCRIPTION
before, the "*" ignore in bower.json was too strong:  despite the "un-ignore"   !dist/0.6/xdomain.js and xdomain.min.js, the parent directory had been ignored, so the un-ignores did not work (see gitignore documentation)
