### PR TITLE
fix ie8 setRequestHeader parameter is invalid

### DIFF
--- a/src/slave.coffee
+++ b/src/slave.coffee
@@ -75,7 +75,7 @@ initSlave = ->
       xhr.timeout = req.timeout if req.timeout
       xhr.responseType = req.type if req.type
       for k,v of req.headers
-        xhr.setRequestHeader k, v
+        xhr.setRequestHeader k, v or ""
 
       #deserialize FormData
       if req.body instanceof Array and req.body[0] is "XD_FD"


### PR DESCRIPTION
fix ie8 setRequestHeader parameter is invalid when slaveCookie value is undefined.
这种情况只会发生在跨域嵌套时，原因未知。例如：
A页面（www.a.com）嵌套B页面（www.b.com），B页面包含xdomain slave配置 b1.b.com/proxy.html
