### PR TITLE
Test script tag src with lower case

### DIFF
--- a/src/xdomain.coffee
+++ b/src/xdomain.coffee
@@ -132,7 +132,7 @@ strip = (src) ->
       masters m
 
   for script in document.getElementsByTagName("script")
-    if /xdomain/.test(script.src)
+    if /xdomain/.test(script.src.toLowerCase())
       for prefix in ['','data-']
         for k,fn of attrs
           fn script.getAttribute prefix+k


### PR DESCRIPTION
An easy mistake you might do is to write XDomain instead of xdomain in the script tag. If you do so the attribute API will not work. Therefore I think the check always should be made with a lower cased version of the script src.
