### PR TITLE
Fix undefined args issue in deserializing form data.

### DIFF
--- a/src/lib/slave.js
+++ b/src/lib/slave.js
@@ -129,7 +129,7 @@ exports.handleSocket = (origin, socket) => {
     if (req.body instanceof Array && req.body[0] === "XD_FD") {
       const fd = new xhook.FormData();
       const entries = req.body[1];
-      Array.from(entries).forEach(arg => {
+      Array.from(entries).forEach(args => {
         //deserialize blobs from arraybuffs
         //[0:marker, 1:real-args, 2:arraybuffer, 3:type]
         if (args[0] === "XD_BLOB" && args.length === 4) {


### PR DESCRIPTION
Love this library! I noticed an issue with the deserializing form data - entries couldn't be deserialized due to an incorrect argument name (probably a typo). "arg" should be "args".

Anyway, here's the pull request. Let me know what you think!