### PR TITLE
Fix postMessage on the host

### DIFF
--- a/src/lib/socket.js
+++ b/src/lib/socket.js
@@ -112,12 +112,11 @@ exports.initialise = () => {
     if (!(d instanceof Array)) {
       return;
     }
-    d = d.slice();
     //return unless lead by an xdomain id
-    const id = d.shift();
-    if (!/^xdomain-/.test(id)) {
+    if (!/^xdomain-/.test(d[0])) {
       return;
     }
+    const id = d.shift();
     //finally, create/get socket
     let socket = sockets[id];
     //closed

--- a/src/lib/socket.js
+++ b/src/lib/socket.js
@@ -112,6 +112,7 @@ exports.initialise = () => {
     if (!(d instanceof Array)) {
       return;
     }
+    d = d.slice();
     //return unless lead by an xdomain id
     const id = d.shift();
     if (!/^xdomain-/.test(id)) {


### PR DESCRIPTION
Currently xdomain modifies the original data array in the postMessage handler, which breaks other scripts on the host that send arrays using postMessage.